### PR TITLE
Fix react admin proxy requests

### DIFF
--- a/routes/api-proxy.js
+++ b/routes/api-proxy.js
@@ -1,12 +1,14 @@
 const {createProxyMiddleware} = require('http-proxy-middleware');
 const apiUrl = process.env.API_URL;
+const siteApiKey = process.env.SITE_API_KEY;
+const authMw = require('../middleware/auth');
 
 module.exports = function(app){
 
     /*
     * Create api route for proxying api so we don't have cross origin errors when making AJAX requests
     */
-   app.use('/api', createProxyMiddleware({
+   app.use('/api', authMw.ensureAuthenticated, authMw.ensureRights, createProxyMiddleware({
      target: apiUrl,
      changeOrigin: true,
      onProxyReq : (proxyReq, req, res) => {
@@ -14,9 +16,7 @@ module.exports = function(app){
         // add custom header to request
         proxyReq.setHeader('Accept', 'application/json');
 
-        if (req.session.jwt) {
-          proxyReq.setHeader('X-Authorization', `Bearer ${req.session.jwt}`);
-        }
+        proxyReq.setHeader('X-Authorization', siteApiKey);
 
         //bodyParser middleware parses the body into an object
         //for proxying to worl we need to turn it back into a string
@@ -39,7 +39,7 @@ module.exports = function(app){
     /*
     * Create api route for proxying api so we don't have cross origin errors when making AJAX requests
     */
-    app.use('/stats', createProxyMiddleware({
+    app.use('/stats', authMw.ensureAuthenticated, authMw.ensureRights, createProxyMiddleware({
      target: apiUrl,
      changeOrigin: true,
      onProxyReq : (proxyReq, req, res) => {
@@ -47,9 +47,7 @@ module.exports = function(app){
         // add custom header to request
         proxyReq.setHeader('Accept', 'application/json');
 
-        if (req.session.jwt) {
-          proxyReq.setHeader('X-Authorization', `Bearer ${req.session.jwt}`);
-        }
+        proxyReq.setHeader('X-Authorization', siteApiKey);
 
      },
      onError: function(err) {


### PR DESCRIPTION
The API is now more restrictive: users can only access endpoints on the site that they belong  to.

As a result the react-admin (beta) section of the management panel no longer works: these request are sent to the API server with the credentials of the management-panel-server but to a specific site.

The other (non-beta) parts of the management server use the SITE_API_KEY for requests to the API.

This hotfix makes sure that proxy requests are handled in a similar way.

